### PR TITLE
Cisco devices return a string for State rather than a int

### DIFF
--- a/check_ospf.py
+++ b/check_ospf.py
@@ -181,7 +181,10 @@ def check_ospf(snmp_check_values):
             if len(chunks) == 4:
                 for key, value in ospf_neighbor_data.items():
                     if chunks[0].startswith(value['Neighbor IP']):
-                        ospf_neighbor_data[key]['State'] = chunks[3]
+                        if isinstance(chunks[3], str):
+                                ospf_neighbor_data[key]['State'] = re.search('.*\((\d)\)', chunks[3]).group(1)
+                        else:
+                                ospf_neighbor_data[key]['State'] = chunks[3]
 
         ### DEBUG OUTPUT
 


### PR DESCRIPTION
Cisco devices return this output :

```
 Name             Data
 -----            -------------------------
 Neighbor000001  {'RID': 'XXX.XXX.XXX.XXX', 'Neighbor IP': 'XXX.XXX.XXX.XXX', 'State': 'full(8)'}
 Neighbor000002  {'RID': 'XXX.XXX.XXX.XXX', 'Neighbor IP': 'XXX.XXX.XXX.XXX', 'State': 'full(8)'}
 Neighbor000003  {'RID': 'XXX.XXX.XXX.XXX', 'Neighbor IP': 'XXX.XXX.XXX.XXX', 'State': 'full(8)'}
 Neighbor000004  {'RID': 'XXX.XXX.XXX.XXX', 'Neighbor IP': 'XXX.XXX.XXX.XXX', 'State': 'full(8)'}

ERROR: Something went wrong parsing data. Probably wrong SNMP OID for this device: invalid literal for int() with base 10: 'full(8)'
```

If chunks[3] is a string, I scan through string with re.search and I look for the digit between brackets.
